### PR TITLE
Added one additional error which allows the 'single' object that do n…

### DIFF
--- a/src/treeview.js
+++ b/src/treeview.js
@@ -75,7 +75,7 @@
           content.appendChild(expando);
           content.appendChild(text);
           leaf.appendChild(content);
-          if (item.children.length > 0) {
+          if (item.children && item.children.length > 0) {
             var children = document.createElement('div');
             children.setAttribute('class', 'tree-child-leaves');
             forEach(item.children, function (child) {


### PR DESCRIPTION
…ot have child without needing empty children property

Hence: 
var tree = new TreeView([
    { name: 'Item 1', children: [] },
    { name: 'Item 2', expanded: true, children: [
            { name: 'Sub Item 1', children: [] },
            { name: 'Sub Item 2', children: [] }
        ]
    }
], 'tree');

Can also be done this way:
var tree = new TreeView([
    { name: 'Item 1' },
    { name: 'Item 2', expanded: true, children: [
            { name: 'Sub Item 1'},
            { name: 'Sub Item 2'}
        ]
    }
], 'tree');

Just a small fix to make it less error prone. 